### PR TITLE
Add BTI to custom assembly

### DIFF
--- a/embed/lib/arch/arm64/trampolines.S.in
+++ b/embed/lib/arch/arm64/trampolines.S.in
@@ -135,6 +135,7 @@ __lfi_trampolines:
 .p2align 4
 .global {{$sym}}
 {{$sym}}:
+	bti jc
 	adrp x10, :got:__lfisym_{{$sym}}
 	ldr x10, [x10, :got_lo12:__lfisym_{{$sym}}]
 	ldr x10, [x10]
@@ -149,6 +150,7 @@ __lfi_trampolines:
 .p2align 4
 .global {{$.lib}}_{{$sym}}
 {{$.lib}}_{{$sym}}:
+	bti jc
 	adrp x10, :got:__lfisym_{{$sym}}
 	ldr x10, [x10, :got_lo12:__lfisym_{{$sym}}]
 	ldr x10, [x10]

--- a/embed/stub/arch/arm64/main.s.in
+++ b/embed/stub/arch/arm64/main.s.in
@@ -2,6 +2,7 @@
 .p2align 4
 .global main
 main:
+	bti c
 	// call _lfi_thread_create(&_lfi_pause)
 	adr x0, _lfi_pause
 	bl _lfi_thread_create
@@ -10,6 +11,7 @@ main:
 	add x0, x0, :lo12:trampotable
 .global _lfi_pause
 _lfi_pause:
+	bti jc
 	mov x8, #94
 	svc #0
 	brk #0


### PR DESCRIPTION
Otherwise, the host process can't have BTI enabled. We rely on the compiler to enable BTI/PAC if needed for the C code. If BTI is not supported, it encodes to a no-op, so we can add it unconditionally.

Sharjeel will built a test compiler so we can verify this is working before we land it.